### PR TITLE
Add option to specify prefix for language tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # README
 
-This script adds starred GitHub repositories as bookmarks in Pinboard. All such bookmarks will be tagged with `github-star` and the project's language (if applicable). The script will attempt to avoid overwriting bookmarks in Pinboard by checking starred repos against the most recent bookmark with the `github-star` tag. If the GitHub repository has a listed language the language will be added as another tag in addition `github-star`, you may set a prefix to the language tag with the `--lang-tag-prefix`.
+This script adds starred GitHub repositories as bookmarks in Pinboard. All such bookmarks will be tagged with github-star and the project's language (if applicable). In addition, you may set a prefix for the language tag with the `--lang-tag-prefix` option. The script will attempt to avoid overwriting bookmarks in Pinboard by checking starred repos against the most recent bookmark with the `github-star` tag.
 
 The script requires a [GitHub personal API token](https://github.com/blog/1509-personal-api-tokens) (see note below) and a [Pinboard API token](https://pinboard.in/settings/password), both of which may be stored in files named `~/.github_api_token` and `~/.pinboard_api_token` respectively instead of passing them as command-line options. Dependencies are best installed with `pip` and `virtualenv`, though you're free to live on the edge and do things like `sudo easy_install requests` if you wish. Just don't say you weren't warned... :smirk:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # README
 
-This script adds starred GitHub repositories as bookmarks in Pinboard. All such bookmarks will be tagged with `github-star` and the project's language (if applicable). The script will attempt to avoid overwriting bookmarks in Pinboard by checking starred repos against the most recent bookmark with the `github-star` tag.
+This script adds starred GitHub repositories as bookmarks in Pinboard. All such bookmarks will be tagged with `github-star` and the project's language (if applicable). The script will attempt to avoid overwriting bookmarks in Pinboard by checking starred repos against the most recent bookmark with the `github-star` tag. If the GitHub repository has a listed language the language will be added as another tag in addition `github-star`, you may set a prefix to the language tag with the `--lang-tag-prefix`.
 
 The script requires a [GitHub personal API token](https://github.com/blog/1509-personal-api-tokens) (see note below) and a [Pinboard API token](https://pinboard.in/settings/password), both of which may be stored in files named `~/.github_api_token` and `~/.pinboard_api_token` respectively instead of passing them as command-line options. Dependencies are best installed with `pip` and `virtualenv`, though you're free to live on the edge and do things like `sudo easy_install requests` if you wish. Just don't say you weren't warned... :smirk:
 
@@ -13,7 +13,7 @@ Run `python pin-github-stars.py -h` for command-line help, which is an essential
 Passing everything on the command line would look like this:
 
 ```
-$ python pin-github-stars.py -g 1234567890abcdef1234567890abcdef123456 -p pbuser:1234567890abcdef1234 -u github_user
+$ python pin-github-stars.py -g 1234567890abcdef1234567890abcdef123456 -p pbuser:1234567890abcdef1234 -u github_user --lang-tag-prefix lang:
 ```
 
 


### PR DESCRIPTION
Using the option `--lang-tag-prefix` a user can now set a prefix for all language tags that are pulled from the GitHub repository language. Useful if a user organizes bookmarks with prefixes for subgroups (languages, file-types, etc...).
